### PR TITLE
[Fix] searchParams에 Suspense 사용

### DIFF
--- a/src/app/(auth)/find-id/result/components/MemberInfo/index.tsx
+++ b/src/app/(auth)/find-id/result/components/MemberInfo/index.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+const MemberInfo = () => {
+  const searchParams = useSearchParams();
+
+  const nickname = searchParams.get('nickname') || '';
+  const memberId = searchParams.get('memberId') || '';
+
+  return (
+    <p className="text-2xl text-[#3C3C3C] font-medium text-center">
+      {nickname}님의 아이디는
+      <br />
+      <span className="text-primary">{memberId}</span>
+      입니다
+    </p>
+  );
+};
+
+export default MemberInfo;

--- a/src/app/(auth)/find-id/result/page.tsx
+++ b/src/app/(auth)/find-id/result/page.tsx
@@ -1,31 +1,19 @@
-'use client';
-
-import { useEffect, useState } from 'react';
+import { Suspense } from 'react';
 import Link from 'next/link';
 
 import { CLIENT_APP_ROUTES } from '@/constants/routes';
 
 import Button from '@/components/Button';
+import MemberInfo from '@/app/(auth)/find-id/result/components/MemberInfo';
+import Spin from '@/components/Spin';
 
 const ResultPage = () => {
-  const [nickname, setNickName] = useState('');
-  const [memberId, setMemberId] = useState('');
-
-  useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    setNickName(searchParams.get('nickname') || '');
-    setMemberId(searchParams.get('memberId') || '');
-  }, []);
-
   return (
     <section className="h-[calc(100%-64px)] pt-[46px] flex flex-col items-center justify-between pb-4 px-5">
       <div className="flex flex-col items-center gap-[104px]">
-        <p className="text-[24px] text-[#3C3C3C] font-medium text-center">
-          {nickname}님의 아이디는
-          <br />
-          <span className="text-[#007AFF]">{memberId}</span>
-          입니다
-        </p>
+        <Suspense fallback={<Spin />}>
+          <MemberInfo />
+        </Suspense>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="133"

--- a/src/components/Spin/index.tsx
+++ b/src/components/Spin/index.tsx
@@ -1,0 +1,8 @@
+const Spin = () => {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="w-16 h-16 border-4 border-gray-300 border-t-primary rounded-full animate-spin"></div>
+    </div>
+  );
+};
+export default Spin;


### PR DESCRIPTION
## 어떤 이유로 PR을 하셨나요?
- [ ] feature 병합
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용을 기입해주세요)

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요
- `Next` 15버전에서 `useSearchParams`에 `Suspense`가 필요해졌습니다. [[문서](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)]
- `Next` 컨벤션에 맞게 이를 수정했습니다.